### PR TITLE
2.1.0 Allow SQL parameters to be included with SortOrders

### DIFF
--- a/Criteria/SortOrder.cs
+++ b/Criteria/SortOrder.cs
@@ -22,6 +22,7 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 
 using System;
+using System.Collections;
 
 namespace Azavea.Open.DAO.Criteria
 {
@@ -35,10 +36,17 @@ namespace Azavea.Open.DAO.Criteria
         /// The data class' property to sort on.
         /// </summary>
         public readonly string Property;
+
         /// <summary>
         /// The direction to sort based on the Property.
         /// </summary>
         public readonly SortType Direction;
+
+        /// <summary>
+        /// Parameters for the expression, if any.  If none, may be null or empty.
+        /// Only used when SortType is SortType.Computed
+        /// </summary>
+        public readonly IEnumerable Parameters;
 
         /// <summary>
         /// A simple class that holds a single sort criterion.
@@ -52,7 +60,7 @@ namespace Azavea.Open.DAO.Criteria
         /// </summary>
         /// <param name="property">The data class' property to sort on.</param>
         /// <param name="direction">The direction to sort based on the Property.</param>
-        public SortOrder(string property, SortType direction)
+        public SortOrder(string property, SortType direction, IEnumerable parameters = null)
         {
             if (property == null)
             {
@@ -61,6 +69,7 @@ namespace Azavea.Open.DAO.Criteria
             }
             Property = property;
             Direction = direction;
+            Parameters = parameters ?? new ArrayList();
         }
 
         ///<summary>

--- a/ProductAssemblyInfo.cs
+++ b/ProductAssemblyInfo.cs
@@ -21,7 +21,7 @@ using System.Reflection;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.0.2.0")]
-[assembly: AssemblyFileVersion("2.0.2.0")]
+[assembly: AssemblyVersion("2.1.0.0")]
+[assembly: AssemblyFileVersion("2.1.0.0")]
 // Used for nuget packaging
-[assembly: AssemblyInformationalVersion("2.0.2")]
+[assembly: AssemblyInformationalVersion("2.1.0")]

--- a/SQL/SqlDaLayer.cs
+++ b/SQL/SqlDaLayer.cs
@@ -503,7 +503,7 @@ namespace Azavea.Open.DAO.SQL
 
         /// <summary>
         /// Converts the list of expressions from this criteria into SQL, and appends to the 
-        /// given string builder.
+        /// given query.
         /// </summary>
         /// <param name="queryToAddTo">Query we're adding the expression to.</param>
         /// <param name="boolType">Whether to AND or OR the expressions together.</param>
@@ -779,18 +779,19 @@ namespace Azavea.Open.DAO.SQL
                 if (crit.Orders.Count > 0)
                 {
                     queryToAddTo.Sql.Append(" ORDER BY ");
-                    OrderListToSql(queryToAddTo.Sql, crit, mapping);
+                    OrderListToSql(queryToAddTo, crit, mapping);
                 }
             }
         }
         /// <summary>
         /// Converts the list of SortOrders from this criteria into SQL, and appends to the
-        /// given string builder.
+        /// given query.
         /// </summary>
-        protected void OrderListToSql(StringBuilder orderClauseToAddTo, DaoCriteria crit,
+        protected void OrderListToSql(SqlDaQuery queryToAddTo, DaoCriteria crit,
                                       ClassMapping mapping)
         {
             bool first = true;
+            var orderClauseToAddTo = queryToAddTo.Sql;
             foreach (SortOrder order in crit.Orders)
             {
                 if (first)
@@ -821,6 +822,13 @@ namespace Azavea.Open.DAO.SQL
                         break;
                     case SortType.Computed:
                         orderClauseToAddTo.Append(order.Property);
+                        if (order.Parameters != null)
+                        {
+                            foreach (object aParam in order.Parameters)
+                            {
+                                queryToAddTo.Params.Add(aParam);
+                            }
+                        }
                         break;
                     default:
                         throw new NotSupportedException("Sort type '" + order.Direction + "' not supported.");

--- a/Tests/AbstractFastDAOTests.cs
+++ b/Tests/AbstractFastDAOTests.cs
@@ -22,6 +22,7 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using Azavea.Open.Common.Collections;
 using Azavea.Open.DAO.Criteria;
@@ -637,6 +638,20 @@ namespace Azavea.Open.DAO.Tests
             int count = _nameDictDAO.GetCount(crit);
 
             Assert.Greater(count, 1, "Should be more than one name in the DB.");
+        }
+
+        /// <exclude />
+        [Test]
+        public void TestGetWithComputedSort()
+        {
+            DaoCriteria crit = new DaoCriteria();
+            var nameField = _nameDAO.ClassMap.AllDataColsByObjAttrs["Name"];
+            var sql = string.Format("CASE WHEN {0} LIKE ? THEN 1 ELSE 2 END", nameField);
+            crit.Orders.Add(new SortOrder(sql, SortType.Computed, new [] { "Michael" }));
+
+            var name = _nameDAO.GetFirst(crit);
+
+            Assert.AreEqual(name.Name, "Michael", "Should always place Michael first");
         }
 
         /// <exclude />


### PR DESCRIPTION
Allow custom SortOrders to specify parameter values

Needed to prevent SQL injection attacks when using SortOrders with
SortType of Computed
