### PR TITLE
Add backwards compatible constructor for SortOrder

### DIFF
--- a/Criteria/SortOrder.cs
+++ b/Criteria/SortOrder.cs
@@ -60,7 +60,16 @@ namespace Azavea.Open.DAO.Criteria
         /// </summary>
         /// <param name="property">The data class' property to sort on.</param>
         /// <param name="direction">The direction to sort based on the Property.</param>
-        public SortOrder(string property, SortType direction, IEnumerable parameters = null)
+        public SortOrder(string property, SortType direction): this(property, direction, null){}
+
+        /// <summary>
+        /// A simple class that holds a single sort criterion.
+        /// </summary>
+        /// <param name="property">The data class' property to sort on.</param>
+        /// <param name="direction">The direction to sort based on the Property.</param>
+        /// <param name="parameters">Parameters corresponding to the substitution tokens 
+        ///     in the property string</param>
+        public SortOrder(string property, SortType direction, IEnumerable parameters)
         {
             if (property == null)
             {

--- a/ProductAssemblyInfo.cs
+++ b/ProductAssemblyInfo.cs
@@ -21,7 +21,7 @@ using System.Reflection;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.1.0.0")]
-[assembly: AssemblyFileVersion("2.1.0.0")]
+[assembly: AssemblyVersion("2.1.1.0")]
+[assembly: AssemblyFileVersion("2.1.1.0")]
 // Used for nuget packaging
-[assembly: AssemblyInformationalVersion("2.1.0")]
+[assembly: AssemblyInformationalVersion("2.1.1")]


### PR DESCRIPTION
SortOrder was recently extended to accept a defulat-null parameter
called `parameters` which were values to be substituted into the
query string in place of ??? tokens.  Even though the parameter
was null by default, the signature was changed and dependent
libraries could no longer find a matching signature, requiring
everything to be updated and recompiled and redeployed to nuget.
Instead, I'm adding a traditional overloaded constructor that
should be backwards compatible with previous versions of the
library.
